### PR TITLE
Use semicolon to split package name and version

### DIFF
--- a/lib/kontent-jekyll/site_processing/kentico_kontent_importer.rb
+++ b/lib/kontent-jekyll/site_processing/kentico_kontent_importer.rb
@@ -79,7 +79,7 @@ module Kentico
         # Add extra headers like tracking
         def custom_headers
           {
-            'X-KC-SOURCE' => "#{GEM_NAME} #{VERSION}",
+            'X-KC-SOURCE' => "#{GEM_NAME};#{VERSION}",
           }
         end
       end


### PR DESCRIPTION
For tracking purposes, we are using a semicolon as a delimiter - some od the package names might contain space - that is why we have chosen this delimiter.